### PR TITLE
Fixed previous PR was missing use state and effect// Added button

### DIFF
--- a/src/components/inventory/InventoryList.js
+++ b/src/components/inventory/InventoryList.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react"
+import { useHistory } from "react-router-dom"
 import { Property } from "./Property"
 
 export const InventoryList = () => {
 
     const [props, updateProperty] = useState([])
    
+    const history = useHistory()
 
     useEffect(() => {
         fetch("http://localhost:8088/storedProperty?_expand=location&_expand=user")
@@ -17,6 +19,7 @@ export const InventoryList = () => {
     
     return (
         <>
+            <button onClick={() => history.push("/inventory/propertyForm")}>New Property</button>
             <div className="property">
                 {
                     props.map(a => <Property key={a.id} prop={a}/>)

--- a/src/components/inventory/Property.js
+++ b/src/components/inventory/Property.js
@@ -2,16 +2,7 @@ import React from "react"
 
 
 export const Property = ({prop}) => {
-    // const [props, updateProperty] = useState([])
-
-    // useEffect(() => {
-    //     fetch("http://localhost:8088/storedProperty?_expand=location&_expand=user")
-    //     .then((res) => res.json())
-    //     .then((PropertyArray) => {
-    //         updateProperty(PropertyArray)
-    //     })
-    // }, [])
-
+    
     return (
         
             <p className="property">
@@ -21,7 +12,7 @@ export const Property = ({prop}) => {
                         --- <br/>VIN:{prop.vin} <br/>
                         SECT: {prop.location?.name}<br/> 
                         Stored: {prop.storedDate} <br/>
-                        Status: {prop.onHold ? `On Hold` : ``}
+                        Status: {prop.onHold ? `On Hold` : `Cleared`}
                    
                 
                

--- a/src/components/inventory/PropertyForm.js
+++ b/src/components/inventory/PropertyForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { useHistory } from "react-router-dom"
 
 export const PropertyForm = () => {
@@ -12,7 +12,16 @@ export const PropertyForm = () => {
         locationId: 0
     })
 
-    const [locations, addLocations] = useState ({})
+    const [locations, addLocation] = useState ([])
+    const [currentLoc, setCurrentLoc] = useState ([])
+
+    useEffect(() => {
+        fetch("http://localhost:8088/locations")
+          .then((res) => res.json())
+          .then((data) => {
+            addLocation(data);
+          });
+      }, []);
 
     const history = useHistory()
 
@@ -26,7 +35,7 @@ export const PropertyForm = () => {
         onHold: property.onHold,
         disposedOf: "",
         userId: parseInt(localStorage.getItem("pbg_user")),
-        locationId: property.locationId
+        locationId: currentLoc
     }
 
     const fetchOption = {
@@ -37,11 +46,16 @@ export const PropertyForm = () => {
         body: JSON.stringify(newProperty)
     }
 
-    return fetch("http://localhost:8088/storedProperty", fetchOption)
+    return fetch("http://localhost:8088/storedProperty?_expand=location", fetchOption)
         .then(() => 
             history.push("/inventory")
     )
 }
+
+const UserLocInput = (event) => {
+    setCurrentLoc(parseInt(event.target.value));
+  };
+
     return (
         <form className="propertyForm">
             <h2 className="propertyForm_title">Add New Prop</h2>
@@ -90,17 +104,13 @@ export const PropertyForm = () => {
             <fieldset>
                 <label htmlFor="location">Location:</label>
                 <select required name="location" className="form-control" 
-                onClick={(evt) => {
-                    const copy = { ...property }
-                    copy.locationId = evt.target.value
-                    addProperty(copy)
-                }}>
+                onChange={UserLocInput}>
                 <option value="0">Select a location</option>
-                    {locations.map((location) => {
-                        <option value={location.id}>
-                            {location.name}
+                    {locations.map((location) => (
+                        <option key={location.id} value={location.id}>
+                          {location.name}
                         </option>
-                    })}                    
+                    ))}                  
 
                 </select>
             </fieldset>


### PR DESCRIPTION
#### Changes Made
1. /propertyForm now uses the correct useState/Effect for assigning locations
1. added a button on /inventory that takes the user to /inventory/propertyForm
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout bb-newPropButton
    ```
2. Open a new Terminal tab and navigate to the server directory.
3. Test app functionality.

- [ ]  Ensure you have the latest version of the api
- [ ]  Start your json server on a new terminal
- [ ]  run `npm start` on your terminal from Step 2
- [ ]  go to /inventory and click New Property button
- [ ]  fill out forms and click submit
- [ ] ensure new entry has been added to the list in /inventory

4. View code file.
    > Confirm file modifications are present as indicated above.
    