### PR TITLE
 history view and disposal button

### DIFF
--- a/src/components/DisposalList.js
+++ b/src/components/DisposalList.js
@@ -5,8 +5,27 @@ import { Property } from "./inventory/Property"
 export const DisposalList = () => {
 
     const [props, updateProperty] = useState([])
-   
-   
+    
+    const todayDate = new Date()
+    const humanDate = () => {
+        const format = {
+            day: "numeric",
+            month: "2-digit",
+            year: "numeric",
+        };
+        return( new Date().toLocaleString(
+            "en-ca",
+            format
+            ))}
+
+    const capturedDate = humanDate(todayDate)   
+    const dateObjBody = {
+        disposedOf: capturedDate
+    }      
+    const sentDisposalDate = dateObjBody
+
+              
+                        
 
     useEffect(() => {
         fetch("http://localhost:8088/storedProperty?_expand=location&_expand=user")
@@ -16,9 +35,13 @@ export const DisposalList = () => {
         })
     }, [])
 
-    const deleteProp = (id) => {
+    const disposeProp = (id) => {
         fetch(`http://localhost:8088/storedProperty/${id}`,{
-            method: "DELETE"
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(sentDisposalDate)
         })
         .then(() => {  
             fetch("http://localhost:8088/storedProperty?_expand=location&_expand=user")
@@ -36,7 +59,7 @@ export const DisposalList = () => {
             
             <div className="property">
                 {
-                    props.map(a => <Property key={a.id} prop={a} deleteProp={deleteProp}/>)
+                    props.map(a => <Property key={a.id} prop={a} disposeProp={disposeProp}/>)
                 }
             </div>
            

--- a/src/components/HistoryList.js
+++ b/src/components/HistoryList.js
@@ -1,17 +1,43 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
+import { Property } from "./inventory/Property"
 
 export const HistoryList = () => {
 
+
+    const [props, updateProperty] = useState([])
+   
+    
+
+    useEffect(() => {
+        fetch("http://localhost:8088/storedProperty?_expand=location&_expand=user")
+        .then((res) => res.json())
+        .then((PropertyArray) => {
+            updateProperty(PropertyArray)
+        })
+    }, [])
+    
+    const deleteProp = (id) => {
+        fetch(`http://localhost:8088/storedProperty/${id}`,{
+            method: "DELETE"
+        })
+        .then(() => {  
+            fetch("http://localhost:8088/storedProperty?_expand=location&_expand=user")
+        .then((res) => res.json())
+        .then((PropertyArray) => {
+            updateProperty(PropertyArray)
+        })
+    }, [])
+}
     return (
-        
+        <>
+            
+                <div className="property">
+                { 
+                    props.map(a => <Property key={a.id} prop={a} deleteProp={deleteProp}/>)
+                }
+            </div>
            
-            
-                <div>
-                    Under Construction
-                </div>
-            
-            
-            
-        
+           
+        </>
     )
 }

--- a/src/components/inventory/Property.js
+++ b/src/components/inventory/Property.js
@@ -3,22 +3,57 @@ import { useLocation } from "react-router-dom"
 
 
 
-export const Property = ({prop, deleteProp}) => {
+export const Property = ({prop, deleteProp, disposeProp}) => {
 
     const CurrentUser = parseInt(localStorage.getItem("pbg_user"))
     const Loc = useLocation()
 
     return (
             <>
+            {
+            Loc.pathname === "/history" && prop.disposedOf != "" ? 
             <p className="property">         
                         --- <br/>VIN:{prop.vin} <br/>
                         SECT: {prop.location?.name}<br/> 
                         Stored: {prop.storedDate} <br/>
-                        Status: {prop.onHold ? `On Hold` : `Cleared`}   
-            </p>
+                        Status: {prop.onHold ? `On Hold` : `Cleared`} <br />        
+                        Disposed: {prop.disposedOf === "" ? `No` : `Yes ( ${prop.disposedOf} )` }
+            </p> : ""
+            }
+            {
+            Loc.pathname === "/inventory" ? 
+            <p className="property">         
+                        --- <br/>VIN:{prop.vin} <br/>
+                        SECT: {prop.location?.name}<br/> 
+                        Stored: {prop.storedDate} <br/>
+                        Status: {prop.onHold ? `On Hold` : `Cleared`} <br />        
+                        Disposed: {prop.disposedOf === "" ? `No` : `Yes`}
+            </p> : ""
+            }
+            {
+            Loc.pathname === "/disposal" && prop.disposedOf === "" ? 
+            <p className="property">         
+                        --- <br/>VIN:{prop.vin} <br/>
+                        SECT: {prop.location?.name}<br/> 
+                        Stored: {prop.storedDate} <br/>
+                        Status: {prop.onHold ? `On Hold` : `Cleared`} <br />        
+                        Disposed: {prop.disposedOf === "" ? `No` : `Yes:`}
+            </p> : ""
+            }
+            
            { 
                 prop.userId === CurrentUser && Loc.pathname === "/inventory"  ? 
                     <button className="btn--propertyDelete" onClick={() => deleteProp(prop.id)} >Delete</button> 
+                : "" 
+            }
+           { 
+                prop.disposedOf != "" && Loc.pathname === "/history"  ? 
+                    <button className="btn--propertyDelete" onClick={() => deleteProp(prop.id)} >Delete</button> 
+                : "" 
+            }
+           { 
+                Loc.pathname === "/disposal" && prop.disposedOf === ""  ? 
+                    <button className="btn--propertyDisposed" onClick={() => disposeProp(prop.id)} >Mark Disposed</button> 
                 : "" 
             }
        


### PR DESCRIPTION
#### Changes Made
1. /history will now render all entries that have a disposal date
1. added button for /disposal view that will add the current date to an entry
1. applied conditionals to selectively render entries and their buttons depending on view/current user/disposal status

#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout bb-historyViewAndDisposalButton
    ```
2. Open a new Terminal tab and navigate to the server directory.
3. Test app functionality.

- [ ]  Ensure you have the latest version of the api
- [ ]  Start your json server on a new terminal
- [ ]  Run `npm start` on your terminal from Step 2
- [ ]  Go to /disposal
- [ ]  Mark entry as disposed
- [ ] Ensure entry has been removed from /disposal and now displays in /history

4. View code file.
    > Confirm file modifications are present as indicated above.